### PR TITLE
Adding extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,8 @@
 		"ms-vscode.vscode-typescript-next",
 		"dbaeumer.vscode-eslint",
 		"hbenl.vscode-test-explorer",
-		"kavod-io.vscode-jest-test-adapter"
+		"kavod-io.vscode-jest-test-adapter",
+		"vsls-contrib.codetour"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-vsliveshare.vsliveshare-pack",
+		"ms-vscode.vscode-typescript-next",
+		"dbaeumer.vscode-eslint",
+		"hbenl.vscode-test-explorer",
+		"kavod-io.vscode-jest-test-adapter"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}


### PR DESCRIPTION
Adds a list of recommended vs code extensions. This aims to make the env setup process a bit simpler.

The users can run the `Show Recommended Extensions` command to see a list of workspace recommended extensions and install what they need.